### PR TITLE
Fix join/leave handling bugs

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -188,7 +188,7 @@ func commandPlay(s *discordgo.Session, g *discordgo.Guild, c *Client, args []str
 // playlist, the entire queue is replaced with that playlist.
 func commandAdd(c *Client, args []string, inPlace bool) {
 	if len(args) < 1 {
-		c.Messagef("Plase specify a URL or a youtube search query.")
+		c.Messagef("Please specify a URL or a youtube search query.")
 		return
 	}
 


### PR DESCRIPTION
* Fixes trumpet announcing users in other channels joining/leaving
* Stops trumpet from leaving the voice channel when a new voice
  session is established
* Adds lock to audio output to ensure that trumpet only announces
  a single event at a time
* Removes trumpet rejoin attempt when user leaves